### PR TITLE
Fix Post Processing

### DIFF
--- a/src/main/java/team/lodestar/lodestone/systems/postprocess/PostProcessHandler.java
+++ b/src/main/java/team/lodestar/lodestone/systems/postprocess/PostProcessHandler.java
@@ -40,11 +40,13 @@ public class PostProcessHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void onWorldRenderLast(RenderLevelStageEvent event) {
-        copyDepthBuffer(); // copy the depth buffer if the mixin didn't trigger
+        if (event.getStage().equals(RenderLevelStageEvent.Stage.AFTER_LEVEL)) {
+            copyDepthBuffer(); // copy the depth buffer if the mixin didn't trigger
 
-        PostProcessor.viewModelStack = event.getPoseStack();
-        instances.forEach(PostProcessor::applyPostProcess);
+            PostProcessor.viewModelStack = event.getPoseStack();
+            instances.forEach(PostProcessor::applyPostProcess);
 
-        didCopyDepth = false; // reset for next frame
+            didCopyDepth = false; // reset for next frame
+        }
     }
 }


### PR DESCRIPTION
This pull request should fix the post processing bug by checking if the render stage is AFTER_LEVEL in the PostProcessHandler onWorldRenderLast method so that the post processing only runs once at the end of the rendering instead of running the post processing for every stage of RenderLevelStageEvent, I made sure to test it with my mod and it seems to work