### PR TITLE
Fixed PostProcessor from copying wrong PoseStack.

### DIFF
--- a/src/main/java/team/lodestar/lodestone/systems/postprocess/PostProcessHandler.java
+++ b/src/main/java/team/lodestar/lodestone/systems/postprocess/PostProcessHandler.java
@@ -40,10 +40,12 @@ public class PostProcessHandler {
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void onWorldRenderLast(RenderLevelStageEvent event) {
+        if (event.getStage().equals(RenderLevelStageEvent.Stage.AFTER_SOLID_BLOCKS)) {
+            PostProcessor.viewModelStack = event.getPoseStack(); // Copy PoseStack from LevelRenderer#renderLevel
+        }
         if (event.getStage().equals(RenderLevelStageEvent.Stage.AFTER_LEVEL)) {
             copyDepthBuffer(); // copy the depth buffer if the mixin didn't trigger
 
-            PostProcessor.viewModelStack = event.getPoseStack();
             instances.forEach(PostProcessor::applyPostProcess);
 
             didCopyDepth = false; // reset for next frame

--- a/src/main/resources/assets/lodestone/shaders/include/common.glsl
+++ b/src/main/resources/assets/lodestone/shaders/include/common.glsl
@@ -28,8 +28,8 @@ float getDepth(sampler2D DepthBuffer, vec2 uv) {
     return texture(DepthBuffer, uv).r;
 }
 
-vec3 worldPos(float mainDepth, vec2 texCoord, mat4 invProjMat, mat4 invViewMat, vec3 cameraPos) {
-    float z = mainDepth * 2.0 - 1.0;
+vec3 getWorldPos(sampler2D DepthBuffer, vec2 texCoord, mat4 invProjMat, mat4 invViewMat, vec3 cameraPos) {
+    float z = getDepth(DepthBuffer, texCoord) * 2.0 - 1.0;
     vec4 clipSpacePosition = vec4(texCoord * 2.0 - 1.0, z, 1.0);
     vec4 viewSpacePosition = invProjMat * clipSpacePosition;
     viewSpacePosition /= viewSpacePosition.w;


### PR DESCRIPTION
Changed worldPos function in common.glsl to getWorldPos
Now uses a sampler2D for depth instead of a float for easier usage.

PostProcessor.viewModelStack is now copied from the LevelRenderer#renderLevel method AFTER_SOLID_BLOCKS instead of AFTER_LEVEL. Fixes issues with the viewMat & invViewMat being identity matrices.