### PR TITLE
Properly register LodestoneFuelItems to FuelRegistry

### DIFF
--- a/src/main/java/team/lodestar/lodestone/systems/item/LodestoneFuelItem.java
+++ b/src/main/java/team/lodestar/lodestone/systems/item/LodestoneFuelItem.java
@@ -11,6 +11,7 @@ public class LodestoneFuelItem extends CombustibleItem {
     public LodestoneFuelItem(Properties properties, int fuel) {
         super(properties);
         this.fuel = fuel;
+        setBurnTime(fuel);
     }
 
     @Override


### PR DESCRIPTION
Fixes Malum items that should be usable as furnace fuel not being usable as such.