### PR TITLE
Only initialize TEST_ITEM in a development environment

### DIFF
--- a/src/main/java/team/lodestar/lodestone/LodestoneLib.java
+++ b/src/main/java/team/lodestar/lodestone/LodestoneLib.java
@@ -35,12 +35,13 @@ public class LodestoneLib implements ModInitializer {
         return new ResourceLocation(LODESTONE, path);
     }
 
-    public static Item TEST_ITEM = new LodestoneFuelItem(new FabricItemSettings(), 200);
+    public static Item TEST_ITEM;
 
     @Override
     public void onInitialize() {
 
         if (FabricLoader.getInstance().isDevelopmentEnvironment()) {
+            TEST_ITEM = new LodestoneFuelItem(new FabricItemSettings(), 200);
             Registry.register(BuiltInRegistries.ITEM, lodestonePath("test"), TEST_ITEM);
         }
 


### PR DESCRIPTION
Fixes the game crashing during startup due to intrusive holders not being registered.

I assume the crash is due to the constructor of `LodestoneFuelItem` registering itself to Fabric's `FuelRegistry`.