### PR TITLE
Move WorldEventEvents.RENDER to separate client-only class

### DIFF
--- a/src/main/java/team/lodestar/lodestone/events/types/worldevent/WorldEventClientEvents.java
+++ b/src/main/java/team/lodestar/lodestone/events/types/worldevent/WorldEventClientEvents.java
@@ -1,0 +1,23 @@
+package team.lodestar.lodestone.events.types.worldevent;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.client.renderer.MultiBufferSource;
+import team.lodestar.lodestone.systems.worldevent.WorldEventInstance;
+import team.lodestar.lodestone.systems.worldevent.WorldEventRenderer;
+
+@Environment(EnvType.CLIENT)
+public class WorldEventClientEvents {
+    public static final Event<Render> RENDER = EventFactory.createArrayBacked(Render.class, callbacks -> (worldEvent, renderer, poseStack, multiBufferSource, partialTicks) -> {
+        for (Render e : callbacks)
+            e.onRender(worldEvent, renderer, poseStack, multiBufferSource, partialTicks);
+    });
+
+    @FunctionalInterface
+    public interface Render {
+        void onRender(WorldEventInstance worldEvent, WorldEventRenderer<WorldEventInstance> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, float partialTicks);
+    }
+}

--- a/src/main/java/team/lodestar/lodestone/events/types/worldevent/WorldEventEvents.java
+++ b/src/main/java/team/lodestar/lodestone/events/types/worldevent/WorldEventEvents.java
@@ -1,12 +1,9 @@
 package team.lodestar.lodestone.events.types.worldevent;
 
-import com.mojang.blaze3d.vertex.PoseStack;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
-import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.world.level.Level;
 import team.lodestar.lodestone.systems.worldevent.WorldEventInstance;
-import team.lodestar.lodestone.systems.worldevent.WorldEventRenderer;
 
 public class WorldEventEvents {
 
@@ -25,11 +22,6 @@ public class WorldEventEvents {
             e.onTick(worldEvent, level);
     });
 
-    public static final Event<Render> RENDER = EventFactory.createArrayBacked(Render.class, callbacks -> (worldEvent, renderer, poseStack, multiBufferSource, partialTicks) -> {
-        for (Render e : callbacks)
-            e.onRender(worldEvent, renderer, poseStack, multiBufferSource, partialTicks);
-    });
-
     @FunctionalInterface
     public interface Creation {
         void onCreation(WorldEventInstance worldEvent, Level level);
@@ -43,11 +35,6 @@ public class WorldEventEvents {
     @FunctionalInterface
     public interface Tick {
         void onTick(WorldEventInstance worldEvent, Level level);
-    }
-
-    @FunctionalInterface
-    public interface Render {
-        void onRender(WorldEventInstance worldEvent, WorldEventRenderer<WorldEventInstance> renderer, PoseStack poseStack, MultiBufferSource multiBufferSource, float partialTicks);
     }
 
 }

--- a/src/main/java/team/lodestar/lodestone/handlers/WorldEventHandler.java
+++ b/src/main/java/team/lodestar/lodestone/handlers/WorldEventHandler.java
@@ -11,6 +11,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import team.lodestar.lodestone.component.LodestoneComponents;
 import team.lodestar.lodestone.component.LodestoneWorldComponent;
+import team.lodestar.lodestone.events.types.worldevent.WorldEventClientEvents;
 import team.lodestar.lodestone.events.types.worldevent.WorldEventEvents;
 import team.lodestar.lodestone.network.worldevent.UpdateWorldEventPacket;
 import team.lodestar.lodestone.registry.client.LodestoneWorldEventRendererRegistry;
@@ -50,7 +51,7 @@ public class WorldEventHandler {
                     WorldEventRenderer<WorldEventInstance> renderer = LodestoneWorldEventRendererRegistry.RENDERERS.get(instance.type);
                     if (renderer != null) {
                         if (renderer.canRender(instance)) {
-                            WorldEventEvents.RENDER.invoker().onRender(instance, renderer, stack, RenderHandler.DELAYED_RENDER.getTarget(), partialTicks);
+                            WorldEventClientEvents.RENDER.invoker().onRender(instance, renderer, stack, RenderHandler.DELAYED_RENDER.getTarget(), partialTicks);
                             renderer.render(instance, stack, RenderHandler.DELAYED_RENDER.getTarget(), partialTicks);
                         }
                     }


### PR DESCRIPTION
Fixes crash on dedicated server (when performing Rites in Malum)