### PR TITLE
Component modifier Items

### DIFF
--- a/src/main/java/team/lodestar/lodestone/systems/item/IComponentResponderItem.java
+++ b/src/main/java/team/lodestar/lodestone/systems/item/IComponentResponderItem.java
@@ -1,0 +1,64 @@
+package team.lodestar.lodestone.systems.item;
+
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponentType;
+import net.neoforged.neoforge.registries.DeferredHolder;
+
+import java.util.Optional;
+
+public interface IComponentResponderItem {
+    default void readComponent(int stackQuantity, DataComponentMap.Builder mutableMap, ComponentGetter originalSupplier) {}
+    default void setComponent(int stackQuantity, DataComponentMap.Builder mutableMap, ModifyComponentOperation<?> diff, ComponentGetter originalSupplier) {}
+    default void removeComponent(int stackQuantity, DataComponentMap.Builder mutableMap, RemoveComponentOperation<?> diff, ComponentGetter originalSupplier) {}
+
+    interface ComponentGetter {
+        <T> Optional<T> get(DataComponentType<T> type);
+
+        default <T> Optional<T> get(DeferredHolder<DataComponentType<?>, DataComponentType<T>> type) {
+            return get(type.get());
+        }
+
+        static ComponentGetter create(DataComponentMap map) {
+            return new IComponentResponderItem.ComponentGetter() {
+                public <T> Optional<T> get(DataComponentType<T> type) {
+                    return Optional.ofNullable(map.get(type));
+                }
+            };
+        }
+    }
+
+    class ModifyComponentOperation<T> extends ComponentOperation<T> {
+        public final T candidate;
+
+        public ModifyComponentOperation(T oldValue, T candidate, DataComponentType<T> type) {
+            super(oldValue, type);
+            this.candidate = candidate;
+        }
+
+        public <T> Optional<ModifyComponentOperation<T>> maybeOfType(DataComponentType<T> type) {
+            return type.equals(this.type) ? Optional.of((ModifyComponentOperation<T>)this) : Optional.empty();
+        }
+    }
+
+    class RemoveComponentOperation<T> extends ComponentOperation<T> {
+
+        public RemoveComponentOperation(T oldValue, DataComponentType<T> type) { super(oldValue, type); }
+
+        public <T> Optional<RemoveComponentOperation<T>> maybeOfType(DataComponentType<T> type) {
+            return type.equals(this.type) ? Optional.of((RemoveComponentOperation<T>)this) : Optional.empty();
+        }
+    }
+
+    class ComponentOperation<T> {
+        public final T oldValue;
+        public final DataComponentType<T> type;
+        public boolean isCancelled = false;
+
+        public ComponentOperation(T oldValue, DataComponentType<T> type) {
+            this.oldValue = oldValue;
+            this.type = type;
+        }
+
+        public void cancel() { isCancelled = true; }
+    }
+}


### PR DESCRIPTION
In a nutshell, `IComponentResponderItem` contains methods to modify components before `read`, `write`, and `remove`. All 3 methods contain a supplier of the components before the would-be operation is executed, the Item stack size, and a `ComponentMap.Builder` for applying changes as necessary. `Write` and `Remove` have additional context.

***
### More detailed explanation

`Write` and `Remove` methods provide a `ComponentOperation` instance, which stores the component type, previous value, and whether the operation is cancelled. 

Implementations contain a `maybeOfType` method, which is equivalent to writing `if (type == DataComponents.SOMETHING)`, just without the casting and compiler errors. Output is given as an `Optional<Operation<Type>>`, for easy use of `ifPresent(e -> e.oldValue.typeSpecificSomething)`

> [!NOTE]
> ItemStacks are not given as a parameter, because otherwise component-related functions could be triggered and cause a recursive error. Count and Component supplier are provided, as well as that implemented methods are called on the contained item, so `this` can be used

### Why on earth would you need this

With the introduction of Components in 1.21, Mojang has phased out classes such as `DyeableItem`, and removed overridable methods such as `getRarity`. While components can be set through `Item.Properties`, values which depend on other components, instance methods, or stack size can no longer be dynamically overwritten, and having custom setter or remove methods is entirely out of the question. This PR brings back that customizability by simply letting you override component get, set, or remove methods.